### PR TITLE
feat: add YAML export support and cleanup ArbConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2024-03-19
+### Added
+- Support for YAML format export (`yaml`) via the export command
+- New examples in README for YAML format export
+- New file extension `.yaml` for exported files
+- Documentation for YAML format in the README
+- Support for metadata preservation in YAML format including descriptions and placeholders
+
+### Changed
+- Updated README with YAML format examples and documentation
+- Removed deprecated conversion methods from ArbConverter class
+- Simplified ArbConverter implementation
+- Made format handling more consistent across converters
+
+### Removed
+- Deprecated format-specific conversion methods in ArbConverter
+
 ## [1.3.0] - 2024-03-19
 ### Added
 - Support for Gettext PO format export (`po`) via the export command

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A command-line utility for managing Dart/Flutter app localizations with enhanced
 - Find and merge ARB files from multiple directories
 - Generate simplified ARB files for Flutter localization
 - Generate metadata-rich ARB files for export
-- Export to **XLIFF**, **JSON**, and **PO** formats with full metadata preservation
+- Export to **XLIFF**, **JSON**, **PO**, and **YAML** formats with full metadata preservation
 - Automatic conflict detection and resolution
 - Support for nested JSON structures
 - Configurable via YAML
@@ -17,7 +17,7 @@ A command-line utility for managing Dart/Flutter app localizations with enhanced
 - `create-config`: Creates a configuration file in your project root
 - `gen-arb`: Generates and merges ARB files from your project
 - `translate`: Creates or updates translation files for specific languages
-- `export`: Exports ARB files to XLIFF, JSON, or PO format with metadata preservation
+- `export`: Exports ARB files to XLIFF, JSON, PO, or YAML format with metadata preservation
 
 ## Installation
 
@@ -25,7 +25,7 @@ Add the package to your `pubspec.yaml` file:
 
 ```yaml
 dev_dependencies:
-  gen_l10n_utils: ^1.3.0
+  gen_l10n_utils: ^1.4.0
 ```
 
 Or install it globally:
@@ -140,6 +140,8 @@ dart run gen_l10n_utils export --format xlf
 dart run gen_l10n_utils export -f json
 # or
 dart run gen_l10n_utils export -f po
+# or
+dart run gen_l10n_utils export -f yaml
 
 # Export specific languages
 dart run gen_l10n_utils export --language en,fr,de
@@ -219,14 +221,32 @@ msgid "Welcome, {username}!"
 msgstr "Willkommen, {username}!"
 ```
 
+Example YAML output (`lib/l10n/yaml/app_de.yaml`):
+```yaml
+metadata:
+  format_version: '1.0'
+  tool: gen_l10n_utils
+translations:
+  greeting:
+    source: "Welcome, {username}!"
+    target: "Willkommen, {username}!"
+    description: "A welcome message with the user's name"
+    placeholders:
+      username:
+        type: String
+        example: John Doe
+        description: The user's display name
+```
+
 Options:
-- `--format` or `-f`: Output format (currently supported: `xlf`, `json`, `po`)
+- `--format` or `-f`: Output format (currently supported: `xlf`, `json`, `po`, `yaml`)
 - `--language` or `-l`: Specific language(s) to export (comma-separated)
 
 Currently supported export formats:
 - `xlf`: XLIFF 1.2 format for translation tools with full metadata preservation
 - `json`: Simplified JSON format with metadata structured for easy processing
 - `po`: Gettext PO format with comments for metadata preservation
+- `yaml`: YAML format with structured metadata for easy reading and editing
 
 ## Directory Structure Requirements
 

--- a/lib/src/cli/commands/export_command.dart
+++ b/lib/src/cli/commands/export_command.dart
@@ -19,7 +19,7 @@ class ExportCommand extends Command<int> {
       'format',
       abbr: 'f',
       help:
-          'Output format (xlf, json, po). If not specified, uses the format from config or defaults to xlf.',
+          'Output format (xlf, json, po, yaml). If not specified, uses the format from config or defaults to xlf.',
     );
     argParser.addOption(
       'language',
@@ -114,7 +114,7 @@ class ExportCommand extends Command<int> {
     try {
       final converter = ArbConverter();
       converter.convert(
-        format: format,
+        format: format.toLowerCase(),
         baseLanguage: baseLanguage,
         languages: languages,
         inputDir: arbDir.path,

--- a/lib/src/utils/arb_converter.dart
+++ b/lib/src/utils/arb_converter.dart
@@ -2,12 +2,14 @@ import 'package:gen_l10n_utils/src/utils/export/format_converter.dart';
 import 'package:gen_l10n_utils/src/utils/export/xliff_converter.dart';
 import 'package:gen_l10n_utils/src/utils/export/json_converter.dart';
 import 'package:gen_l10n_utils/src/utils/export/po_converter.dart';
+import 'package:gen_l10n_utils/src/utils/export/yaml_converter.dart';
 
 class ArbConverter {
   final Map<String, FormatConverter> _converters = {
     'xlf': XliffConverter(),
     'json': JsonConverter(),
     'po': PoConverter(),
+    'yaml': YamlConverter(),
   };
 
   /// Converts ARB files to the specified format
@@ -35,55 +37,4 @@ class ArbConverter {
 
   /// Returns a list of supported export formats
   List<String> get supportedFormats => _converters.keys.toList();
-
-  /// For backward compatibility - use convert() instead
-  @Deprecated('Use convert() with format="xlf" instead')
-  void convertToXlf({
-    required String baseLanguage,
-    required List<String> languages,
-    required String inputDir,
-    required String outputDir,
-  }) {
-    convert(
-      format: 'xlf',
-      baseLanguage: baseLanguage,
-      languages: languages,
-      inputDir: inputDir,
-      outputDir: outputDir,
-    );
-  }
-
-  /// For backward compatibility - use convert() instead
-  @Deprecated('Use convert() with format="json" instead')
-  void convertToJson({
-    required String baseLanguage,
-    required List<String> languages,
-    required String inputDir,
-    required String outputDir,
-  }) {
-    convert(
-      format: 'json',
-      baseLanguage: baseLanguage,
-      languages: languages,
-      inputDir: inputDir,
-      outputDir: outputDir,
-    );
-  }
-
-  /// For backward compatibility - use convert() instead
-  @Deprecated('Use convert() with format="po" instead')
-  void convertToPo({
-    required String baseLanguage,
-    required List<String> languages,
-    required String inputDir,
-    required String outputDir,
-  }) {
-    convert(
-      format: 'po',
-      baseLanguage: baseLanguage,
-      languages: languages,
-      inputDir: inputDir,
-      outputDir: outputDir,
-    );
-  }
 }

--- a/lib/src/utils/export/yaml_converter.dart
+++ b/lib/src/utils/export/yaml_converter.dart
@@ -1,0 +1,109 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as path;
+import 'package:yaml_edit/yaml_edit.dart';
+import 'package:gen_l10n_utils/src/utils/export/format_converter.dart';
+
+class YamlConverter implements FormatConverter {
+  @override
+  void convert({
+    required String baseLanguage,
+    required List<String> languages,
+    required String inputDir,
+    required String outputDir,
+  }) {
+    final baseContent = _readArbFile(
+      path.join(inputDir, 'metadata', 'app_${baseLanguage}_metadata.arb'),
+    );
+
+    for (final language in languages) {
+      if (language == baseLanguage) continue;
+
+      final targetContent = _readArbFile(
+        path.join(inputDir, 'metadata', 'app_${language}_metadata.arb'),
+      );
+
+      final yaml = convertToYaml(
+        sourceContent: baseContent,
+        targetContent: targetContent,
+      );
+
+      final outputPath = path.join(outputDir, 'yaml', 'app_$language.yaml');
+      _ensureDirectoryExists(outputPath);
+      saveToFile(yaml, outputPath);
+    }
+  }
+
+  /// Converts ARB content to YAML format
+  String convertToYaml({
+    required Map<String, dynamic> sourceContent,
+    required Map<String, dynamic> targetContent,
+  }) {
+    final translations = <String, dynamic>{};
+
+    // Process each translation entry
+    for (final key in sourceContent.keys) {
+      if (!key.startsWith('@')) {
+        final metadata = sourceContent['@$key'] as Map<String, dynamic>?;
+        final source = sourceContent[key] as String;
+        final target = targetContent[key] as String?;
+
+        translations[key] = _createTranslationEntry(
+          source: source,
+          target: target,
+          metadata: metadata,
+        );
+      }
+    }
+
+    final document = {
+      'metadata': {
+        'format_version': '1.0',
+        'tool': 'gen_l10n_utils',
+      },
+      'translations': translations,
+    };
+
+    final yamlEditor = YamlEditor('');
+    yamlEditor.update([], document);
+    return yamlEditor.toString();
+  }
+
+  Map<String, dynamic> _createTranslationEntry({
+    required String source,
+    String? target,
+    Map<String, dynamic>? metadata,
+  }) {
+    return {
+      'source': source,
+      'target': target ?? '',
+      if (metadata != null) ...{
+        if (metadata['description'] != null)
+          'description': metadata['description'],
+        if (metadata['placeholders'] != null)
+          'placeholders': metadata['placeholders'],
+      },
+    };
+  }
+
+  /// Saves YAML content to a file
+  void saveToFile(String yaml, String outputPath) {
+    final file = File(outputPath);
+    file.writeAsStringSync(yaml);
+  }
+
+  Map<String, dynamic> _readArbFile(String filePath) {
+    final file = File(filePath);
+    if (!file.existsSync()) {
+      throw Exception('File not found: $filePath');
+    }
+    return jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+  }
+
+  void _ensureDirectoryExists(String filePath) {
+    final directory = path.dirname(filePath);
+    if (!Directory(directory).existsSync()) {
+      Directory(directory).createSync(recursive: true);
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gen_l10n_utils
 description: A CLI tool for merging, flattening, and managing gen_l10n translation files.
-version: 1.3.0
+version: 1.4.0
 repository: https://github.com/AppMinds-dev/gen_l10n_utils
 homepage: https://appminds.dev
 documentation: https://github.com/AppMinds-dev/gen_l10n_utils/wiki


### PR DESCRIPTION
- Add YAML converter implementation with metadata preservation
- Add YAML format documentation and examples to README
- Remove deprecated format-specific methods from ArbConverter
- Update CHANGELOG.md for version 1.4.0