### PR TITLE
fix: properly handle nested keys in ARB file generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2025-03-20
+
+### Fixed
+- Fixed ARB file generation where nested translation keys were not properly handled:
+  - Simplified ARB files (`app_*.arb`) now correctly include flattened nested keys while excluding metadata keys (starting with `@`)
+  - Metadata ARB files (`metadata/app_*_metadata.arb`) now preserve the original nested structure
+
 ## [1.7.0] - 2025-03-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the package to your `pubspec.yaml` file:
 
 ```yaml
 dev_dependencies:
-  gen_l10n_utils: ^1.7.0
+  gen_l10n_utils: ^1.7.1
 ```
 
 Or install it globally:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gen_l10n_utils
 description: A CLI tool for merging, flattening, and managing gen_l10n translation files.
-version: 1.7.0
+version: 1.7.1
 repository: https://github.com/AppMinds-dev/gen_l10n_utils
 homepage: https://appminds.dev
 documentation: https://github.com/AppMinds-dev/gen_l10n_utils/wiki


### PR DESCRIPTION
- Include flattened nested keys in simplified ARB files (app_*.arb)
- Preserve original nested structure in metadata ARB files
- Exclude metadata keys starting with @ from simplified ARB files
- Update MergeResult to store original unflattened content